### PR TITLE
fix: correct mysql env variables for successful container startup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,5 @@
-version: '3.9'
+version: "3.9"
+
 services:
   backend:
     container_name: backend
@@ -12,13 +13,13 @@ services:
       - 8000:8000
     depends_on:
       - db
+
   db:
     image: mysql:8
+    container_name: auth-api-main-db-1
     restart: always
     environment:
       MYSQL_DATABASE: auth
-      MYSQL_USER: root
-      MYSQL_PASSWORD: root
       MYSQL_ROOT_PASSWORD: root
     volumes:
       - .dbdata:/var/lib/mysql


### PR DESCRIPTION
This PR fixes the MySQL container startup issue caused by a conflict between MYSQL_USER and MYSQL_ROOT_PASSWORD. 
